### PR TITLE
fix(ui): LankaEvents page refinements + restore dark footer on landing page

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -326,7 +326,7 @@ export default function LankaConnectHome() {
 
       {/* Footer — satellite-navy gradient continues from hero */}
       <div style={{ background: 'linear-gradient(180deg, #020818 0%, #0a0f2e 50%, #030d1a 100%)' }}>
-        <Footer />
+        <Footer transparent={true} />
       </div>
 
     </div>


### PR DESCRIPTION
## Summary

- Fix dark navy footer on `/` landing page (was showing orange/rose gradient after Footer got a default background)
- LankaEvents card compacted to 50px height, image 55px, description → "Plan Your Event with Ease"
- Remove pulse ring blast from world map animation (just city nodes + beam now)
- CSS classes `.brand-title` (1.65rem/700) and `.brand-tagline` (0.645em) for LankaEvents header
- `.card-tagline` (0.62rem) for landing page card tagline
- Add `WhatsAppSettings__Enabled=true` to `deploy-production.yml` (parity with staging)

## No migrations

Frontend-only changes + one CI workflow fix. No database migrations.

## Test plan
- [ ] `/` landing page footer shows dark navy background (not orange)
- [ ] `/lanka-events` footer inherits the page gradient (transparent)
- [ ] All other pages footer shows orange/rose/emerald gradient with cross pattern
- [ ] LankaEvents card on `/` is compact with correct text

🤖 Generated with [Claude Code](https://claude.com/claude-code)