### PR TITLE
chore(phase-a): replace CODEOWNERS + add PR template + create labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,43 +1,28 @@
-# Global code owners
-* @devops-team @senior-developers
+# CODEOWNERS for LankaConnect (Phase A baseline — solo founder + AI agents)
+#
+# Why this file was rewritten (2026-05-11):
+# The prior CODEOWNERS referenced 15 team handles (@devops-team, @senior-developers,
+# @domain-architects, @infrastructure-team, @application-team, @api-team,
+# @cultural-intelligence-team, @test-engineers, @qa-team, @database-team,
+# @technical-writers, @product-team, @security-team, @configuration-team,
+# @ci-maintainers). None of these resolve as real GitHub teams or users for this
+# repo, so GitHub silently ignored every rule. Result: zero enforcement, false
+# sense of governance.
+#
+# Path rules below activate as the repo's structure evolves during Phase A.
+# Rules referencing non-existent paths are harmless no-ops until those paths exist.
+# See docs/architecture/ADR-004-feature-flag-strategy.md for the broader discipline.
 
-# GitHub Actions and CI/CD
-/.github/ @devops-team @ci-maintainers
+# Default owner — catches everything not matched by a more specific rule below
+* @Niroshana-SinharaRalalage
 
-# Core Domain Layer - Requires architect approval
-/src/LankaConnect.Domain/ @domain-architects @senior-developers
+# Phase A modular monolith paths (activate when src/Modules/* directories exist; W2+)
+/src/Modules/*/Domain/** @Niroshana-SinharaRalalage
+/src/Modules/*/Infrastructure/Migrations/** @Niroshana-SinharaRalalage
 
-# Infrastructure Layer - Requires DevOps approval  
-/src/LankaConnect.Infrastructure/ @devops-team @infrastructure-team
+# Architecture decision records — every change should pause for explicit review
+/docs/architecture/** @Niroshana-SinharaRalalage
 
-# Application Layer - Requires feature team approval
-/src/LankaConnect.Application/ @application-team @senior-developers
-
-# API Layer - Requires API team approval
-/src/LankaConnect.API/ @api-team @senior-developers
-
-# Cultural Intelligence - Requires cultural team approval
-/src/**/Cultural*/ @cultural-intelligence-team @domain-architects
-/src/**/Sacred*/ @cultural-intelligence-team @senior-developers
-
-# Test Files - Requires test engineering approval
-/tests/ @test-engineers @qa-team
-
-# Database and Migrations
-/src/LankaConnect.Infrastructure/Database/ @database-team @devops-team
-/src/LankaConnect.Infrastructure/Migrations/ @database-team @devops-team
-
-# Documentation
-/docs/ @technical-writers @product-team
-/README.md @technical-writers @product-team
-
-# Configuration Files
-docker-compose*.yml @devops-team
-*.json @configuration-team
-*.yml @devops-team
-*.yaml @devops-team
-
-# Security Sensitive
-/src/**/*Auth*/ @security-team @senior-developers
-/src/**/*Security*/ @security-team @senior-developers
-/src/**/*Encryption*/ @security-team @senior-developers
+# CI/CD workflows — changes have global blast radius
+/.github/workflows/** @Niroshana-SinharaRalalage
+/.github/actions/** @Niroshana-SinharaRalalage

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+This template is required for ALL PRs after 2026-05-11.
+
+For Phase A modular monolith refactor PRs:
+  - Apply the `phase-a` label
+  - Title format MUST be: `W#.#: <imperative summary>` (e.g., `W3.1: extract Notifications module skeleton`)
+  - Allowed prefixes for non-task PRs: `Merge`, `Revert`, `[hotfix]`
+  - The `phase-a` label is the activation switch for the PR-title gate (introduced by PR-B)
+
+For operational / non-Phase-A PRs:
+  - Leave the `phase-a` label OFF
+  - Mark the "Operational (no Phase A scope)" checkbox under "PR type" below
+  - Sections referencing Phase A tracking can be marked N/A
+
+Plan reference: C:\Users\Niroshana\.claude\plans\yes-one-cart-per-streamed-rocket.md
+Master TODO: docs/MASTER_TODO_PHASE_A_MODULAR_MONOLITH.md
+-->
+
+## Master TODO task
+- **Task ID**: <!-- W#.# from MASTER_TODO_PHASE_A_MODULAR_MONOLITH.md, or N/A for operational -->
+- **Playbook section**: <!-- link to PHASE_A_IMPLEMENTATION_PLAYBOOK.md anchor (W1 onwards), or N/A -->
+- **PR type**:
+  - [ ] Scaffolding (≤1000 LOC; module skeleton, ArchTest, DI extension, sln updates)
+  - [ ] Behavior (≤400 LOC hard ceiling; functional/refactor change)
+  - [ ] Operational (no Phase A scope)
+
+## Summary
+<!-- 1-3 sentences: what this PR changes and why -->
+
+## Pass/Fail criteria from playbook
+<!-- Paste evidence (curl output, SQL row count, dotnet test result) for each criterion -->
+- [ ] Verification step 1: <evidence>
+- [ ] Verification step 2: <evidence>
+- [ ] Exit criteria observable on staging: <curl + response>
+
+## Blast radius
+<!-- For module-extraction PRs: paste grep results showing who calls the code being moved -->
+<!-- For operational PRs: N/A -->
+
+## Feature flag impact
+- **New flag**: <name | none>
+- **Default**: <false | n/a>
+- **Cleanup-by date**: <W# | n/a>
+
+## Rollback plan
+<!-- Specific commands or steps -->
+- <git revert hash | flag flip command | migration down-script confirmed>
+
+## Architect review needed?
+- [ ] **Yes** — module extraction, cleanup PR, or `point-of-no-return` label
+- [ ] **No** — internal refactor within a module, or operational change
+
+## Test plan
+<!-- Bulleted checklist of what to verify (CI gates + manual smoke + staging API tests) -->
+- [ ]
+- [ ]


### PR DESCRIPTION
## Summary
PR-A of Phase A pre-flight sequence. Establishes governance infrastructure before PR-B (PR-title regex gate) and PR-C (first labeled Phase A task).

## What changed

### `.github/CODEOWNERS` — full replace (per ADR-004 architect amendment)
The prior file referenced **15 fictional team handles** (`@devops-team`, `@senior-developers`, `@domain-architects`, `@infrastructure-team`, `@application-team`, `@api-team`, `@cultural-intelligence-team`, `@test-engineers`, `@qa-team`, `@database-team`, `@technical-writers`, `@product-team`, `@security-team`, `@configuration-team`, `@ci-maintainers`). None of these resolve as real GitHub teams or users on this repo, so GitHub **silently ignored every rule** — zero enforcement, false sense of governance.

Replaced with solo-founder owner (`@Niroshana-SinharaRalalage`) + path rules that activate as Phase A structure evolves:
- `*` → default owner
- `/src/Modules/*/Domain/**` — activates when modules exist (W2+)
- `/src/Modules/*/Infrastructure/Migrations/**` — same
- `/docs/architecture/**` — every ADR change paused for explicit review
- `/.github/workflows/**` and `/.github/actions/**` — CI/CD changes have global blast radius

### `.github/pull_request_template.md` — new file
Required template for ALL PRs after this lands. Captures:
- Master TODO task ID (W#.# for Phase A, N/A for operational)
- Pass/Fail criteria with evidence boxes
- Blast radius (grep results)
- Feature flag impact + cleanup-by date
- Rollback plan
- Architect review checkbox (drives CODEOWNERS forcing function)
- Test plan

### Labels created (out-of-band; not in diff)
Via `gh label create` after this PR opens:
- **`phase-a`** (color `FBCA04` yellow) — activates PR-title regex gate via PR-B
- **`point-of-no-return`** (color `B60205` red) — triggers CODEOWNERS forcing function for irreversible module cutovers

Verified: ` gh label list --search phase-a` and ` gh label list --search point-of-no-return` both return the labels.

## This PR is intentionally NOT labeled \`phase-a\`
- PR-B's gate doesn't exist yet (cold-start safety per architect's amendment)
- Bundling docs + workflow changes under one PR keeps the foundation tight
- Expected to pass current `pr-validation.yml` unchanged (no code/.NET changes)

## Test plan
- [ ] PR-validation workflow passes (only docs + governance files touched; Domain/Infra/Application layers unaffected)
- [ ] After merge: verify `.github/CODEOWNERS` is the new content (not the old fictional-teams version)
- [ ] After merge: open a dummy throwaway PR to confirm the new template auto-populates the description field

## After merge
**Next: PR-B** — add PR-title regex gate to `pr-validation.yml` as a separate job (per plan §2.6 Layer 1). Job runs only on PRs labeled \`phase-a\`. Title format: \`W#.#: <imperative>\` with allowed prefixes \`Merge\`, \`Revert\`, \`[hotfix]\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)