### PR TITLE
ci: add workflow_call trigger to prod deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,6 +10,11 @@ on:
         description: 'Skip tests (emergency deployment only)'
         required: false
         default: 'false'
+  # Reusable trigger so deploy-production-with-approval.yml can call this
+  # workflow via `uses: ./.github/workflows/deploy-production.yml`. Without
+  # this trigger, the wrapper dispatch fails with "workflow is not reusable
+  # as it is missing a `on.workflow_call` trigger".
+  workflow_call:
 
 env:
   AZURE_CONTAINER_REGISTRY: lankaconnectprod

--- a/.github/workflows/deploy-ui-production.yml
+++ b/.github/workflows/deploy-ui-production.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+  # Reusable trigger so deploy-production-with-approval.yml can call this
+  # workflow via `uses: ./.github/workflows/deploy-ui-production.yml`.
+  workflow_call:
 
 # Run name surfaces the trigger SHA + event so the Actions list reads e.g.
 # "UI prod · 85aa3a71 · push" — makes it trivial to reconstruct whether a run


### PR DESCRIPTION
Fast-follow CI fix for PR #123. Adds `on.workflow_call:` to both `deploy-production.yml` and `deploy-ui-production.yml` so the wrapper `deploy-production-with-approval.yml` can call them via `uses: ./.github/workflows/...`.

Without this, dispatching the wrapper fails with HTTP 422 "workflow is not reusable as it is missing a `on.workflow_call` trigger". Discovered when trying to fire the 6A.141 production deploy.

Push/dispatch behavior unchanged — `on.push.branches: [main]` and `workflow_dispatch` still work exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)