### PR TITLE
fix(ops): preserve Refund:ApprovalWorkflow:Enabled flag on every deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -204,6 +204,7 @@ jobs:
               Stripe__SecretKey=secretref:stripe-secret-key \
               Stripe__PublishableKey=secretref:stripe-publishable-key \
               Stripe__WebhookSecret=secretref:stripe-webhook-secret \
+              Refund__ApprovalWorkflow__Enabled=true \
               WhatsAppSettings__Enabled=true \
               WhatsAppSettings__Provider=Twilio \
               WhatsAppSettings__TwilioAccountSid=secretref:twilio-account-sid \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -271,6 +271,7 @@ jobs:
               Stripe__SecretKey=secretref:stripe-secret-key \
               Stripe__PublishableKey=secretref:stripe-publishable-key \
               Stripe__WebhookSecret=secretref:stripe-webhook-secret \
+              Refund__ApprovalWorkflow__Enabled=true \
               WhatsAppSettings__Enabled=true \
               WhatsAppSettings__Provider=Twilio \
               WhatsAppSettings__TwilioAccountSid=secretref:twilio-account-sid \


### PR DESCRIPTION
## Summary
Adds `Refund__ApprovalWorkflow__Enabled=true` to the `--replace-env-vars` list in both `deploy-production.yml` and `deploy-staging.yml`.

## Root cause
Both workflows use `az containerapp update --replace-env-vars` (not `--set-env-vars`), which **wipes any env var not in the hardcoded list**. The Refund flag was never in the list, so it got dropped on every deploy and the 7 refund endpoints (gated on this flag per Phase 6A.148 design) returned 404 until manually re-set via az CLI.

## Empirical evidence
- 2026-05-29 prod (this session): visited `lankaconnect.app/events/{id}/manage` → "Refund Requests" tab → 404
- Container env-var dump showed `Refund__ApprovalWorkflow__Enabled` not present on either prod or staging
- After `az containerapp update --set-env-vars Refund__ApprovalWorkflow__Enabled=true`: same endpoint returns 401 (auth gate reached, route alive)

## Why this matches "happens with every prod deployment"
The manual `az` set survives until the next workflow deploy, then `--replace-env-vars` wipes it again. Without this PR, the cycle repeats forever.

## Risk
Zero. Adding one env var the app already documents in `appsettings.json:206`:
> "Default OFF so dev/local behavior is unchanged; staging/prod opt in via Container App env var `Refund__ApprovalWorkflow__Enabled=true`."

## Test plan
- [ ] Merge to main
- [ ] Cherry-pick / open companion PR to Production_05_09_2026
- [ ] Next prod deploy preserves the flag (verifiable via `az containerapp show ... --query "properties.template.containers[0].env[?name=='Refund__ApprovalWorkflow__Enabled']"`)

Companion PR coming for Production_05_09_2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)